### PR TITLE
[nl] Fix the text on the potion contest pamphlet

### DIFF
--- a/nl/Pepper-and-Carrot_by-David-Revoy_E03P03.svg
+++ b/nl/Pepper-and-Carrot_by-David-Revoy_E03P03.svg
@@ -13,7 +13,7 @@
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r"
+   inkscape:version="0.91 r13725"
    width="2481"
    height="3503"
    sodipodi:docname="Pepper-and-Carrot_by-David-Revoy_E03P03.svg"
@@ -629,16 +629,15 @@
        y1="2316.8098"
        x2="1024.5358"
        y2="1619.6255" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5427-1-2"
-       id="linearGradient4363"
-       gradientUnits="userSpaceOnUse"
-       x1="618.94147"
-       y1="2316.8098"
-       x2="1024.5358"
-       y2="1619.6255"
-       gradientTransform="matrix(0.7080212,-0.14309456,0.51212683,0.7689921,-371.68363,837.65337)" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3486">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.27231681px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 1160.3809,1737.5522 -75.0143,10.4426 -48.1047,33.1963 -29.7004,37.7301 -16.96808,26.7895 -3.88126,17.0242 3.19402,13.9041 16.28552,10.7944 10.6198,5.3035 36.8109,12.3957 -691.42754,63.2211 17.8173,-346.066 787.38664,25.6203 z"
+         id="path3488"
+         inkscape:connector-curvature="0" />
+    </clipPath>
   </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -649,15 +648,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1600"
-     inkscape:window-height="876"
+     inkscape:window-width="1920"
+     inkscape:window-height="995"
      id="namedview4"
      showgrid="false"
-     inkscape:zoom="0.41451838"
-     inkscape:cx="723.13516"
-     inkscape:cy="1532.1487"
-     inkscape:window-x="1276"
-     inkscape:window-y="121"
+     inkscape:zoom="0.5"
+     inkscape:cx="978.48158"
+     inkscape:cy="1274.1309"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
      inkscape:current-layer="layer4" />
   <g
@@ -666,13 +665,13 @@
      inkscape:label="artwork"
      sodipodi:insensitive="true">
     <image
-       sodipodi:absref="/home/deevad/Production/Webcomics/2014-10-02_ep03_The-secret-ingredients/lang/nl/../gfx_Pepper-and-Carrot_by-David-Revoy_E03P03.png"
+       sodipodi:absref="/home/willem/Git/peppercarrot_ep03_translation/nl/../gfx_Pepper-and-Carrot_by-David-Revoy_E03P03.png"
        xlink:href="../gfx_Pepper-and-Carrot_by-David-Revoy_E03P03.png"
-       y="0"
-       x="0"
-       id="image10"
+       width="2481"
        height="3503"
-       width="2481" />
+       id="image10"
+       x="0"
+       y="0" />
     <flowRoot
        xml:space="preserve"
        id="flowRoot5790"
@@ -758,7 +757,7 @@
        xml:space="preserve"
        id="flowRoot3755"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:67.07809448px;line-height:125%;font-family:Arial;-inkscape-font-specification:Arial;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba894f;fill-opacity:1;fill-rule:nonzero;stroke:#7b441d;stroke-width:5.05978775;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       transform="matrix(0.80269979,-0.12937304,0.44149486,0.85519661,-675.5857,432.32671)"><flowRegion
+       transform="matrix(0.80269979,-0.12937304,0.44149486,0.85519661,-685.82081,434.03256)"><flowRegion
          id="flowRegion3757"
          style="fill:url(#linearGradient5441);fill-opacity:1"><rect
            id="rect3759"
@@ -771,10 +770,11 @@
          id="flowPara3476">Toverdrankwedstrijd</flowPara><flowPara
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:67.07809448px;font-family:Fondamento;-inkscape-font-specification:Fondamento;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba894f;fill-opacity:1;fill-rule:nonzero;stroke:#7b441d;stroke-width:5.05978775;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          id="flowPara4292">van Komona</flowPara></flowRoot>    <flowRoot
-       transform="matrix(0.7080212,-0.14309456,0.51212683,0.7689921,-628.20579,760.93812)"
+       transform="matrix(0.7080212,-0.14309456,0.51212683,0.7689921,-643.58943,765.61173)"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:67.07809448px;line-height:125%;font-family:Arial;-inkscape-font-specification:Arial;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba894f;fill-opacity:1;fill-rule:nonzero;stroke:#7b441d;stroke-width:5.37446117;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="flowRoot3351"
-       xml:space="preserve"><flowRegion
+       xml:space="preserve"
+       clip-path="url(#clipPath3486)"><flowRegion
          style="fill:url(#linearGradient3375);fill-opacity:1"
          id="flowRegion3353"><rect
            style="color:#000000;font-size:67.07809448px;text-align:center;text-anchor:middle;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba894f;fill-opacity:1;fill-rule:nonzero;stroke:#7b441d;stroke-width:5.37446117;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
@@ -786,13 +786,13 @@
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:67.07809448px;font-family:Fondamento;-inkscape-font-specification:Fondamento;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba894f;fill-opacity:1;fill-rule:nonzero;stroke:#7b441d;stroke-width:5.37446117;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          id="flowPara3506">Hoofdprijs: 50000 Ko</flowPara><flowPara
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:67.07809448px;font-family:Fondamento;-inkscape-font-specification:Fondamento;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba894f;fill-opacity:1;fill-rule:nonzero;stroke:#7b441d;stroke-width:5.37446117;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         id="flowPara3537">voor de BESTE</flowPara><flowPara
+         id="flowPara3539">voor de BESTE</flowPara><flowPara
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:67.07809448px;font-family:Fondamento;-inkscape-font-specification:Fondamento;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba894f;fill-opacity:1;fill-rule:nonzero;stroke:#7b441d;stroke-width:5.37446117;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         id="flowPara3539">TOVERDRA       </flowPara></flowRoot>    <flowRoot
+         id="flowPara3482">TOVERDRANK</flowPara></flowRoot>    <flowRoot
        xml:space="preserve"
        id="flowRoot3395"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:67.07809448px;line-height:125%;font-family:Arial;-inkscape-font-specification:Arial;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ba894f;fill-opacity:1;stroke:#7b441d;color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-rule:nonzero;stroke-width:5.05978785;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;"
-       transform="matrix(0.73981395,-0.16569197,0.58529146,0.81100502,-590.38221,1003.6234)"><flowRegion
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:67.07809448px;line-height:125%;font-family:Arial;-inkscape-font-specification:Arial;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba894f;fill-opacity:1;fill-rule:nonzero;stroke:#7b441d;stroke-width:5.05978775;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       transform="matrix(0.73981395,-0.16569197,0.58529146,0.81100502,-627.1761,978.741)"><flowRegion
          id="flowRegion3397"
          style="fill:url(#linearGradient3419);fill-opacity:1"><rect
            id="rect3399"
@@ -800,13 +800,9 @@
            height="841.94098"
            x="296.72992"
            y="1655.0723"
-           style="font-size:67.07809448px;text-align:center;text-anchor:middle;fill:#ba894f;fill-opacity:1;color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-rule:nonzero;stroke:#7b441d;stroke-width:5.05978785;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;" /></flowRegion><flowPara
+           style="color:#000000;font-size:67.07809448px;text-align:center;text-anchor:middle;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba894f;fill-opacity:1;fill-rule:nonzero;stroke:#7b441d;stroke-width:5.05978775;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /></flowRegion><flowPara
          id="flowPara3413"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:67.07809448px;font-family:Fondamento;-inkscape-font-specification:Fondamento;fill:#ba894f;fill-opacity:1;color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-rule:nonzero;stroke:#7b441d;stroke-width:5.05978785;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;">Op Azerdag 3 Paarsmaan</flowPara><flowPara
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:67.07809448px;font-family:Fondamento;-inkscape-font-specification:Fondamento;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba894f;fill-opacity:1;fill-rule:nonzero;stroke:#7b441d;stroke-width:5.05978775;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate">Op Azerdag, om 3 Paarsmaan</flowPara><flowPara
          id="flowPara3415"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:67.07809448px;font-family:Fondamento;-inkscape-font-specification:Fondamento;fill:#ba894f;fill-opacity:1;color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-rule:nonzero;stroke:#7b441d;stroke-width:5.05978785;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;">Grote Markt, Komona</flowPara></flowRoot>    <path
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:67.07809448px;line-height:125%;font-family:Fondamento;-inkscape-font-specification:Fondamento;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:url(#linearGradient4363);fill-opacity:1;stroke:none"
-       d="M 1063.6016 1987.9648 C 1056.7626 1989.347 1053.1992 1990.7106 1052.9102 1992.0566 C 1052.5072 1993.9329 1051.9629 1998.1601 1051.2773 2004.7363 C 1051.2132 2005.3403 1051.135 2005.8739 1051.0645 2006.4473 L 1060.4766 2005.416 C 1060.5104 2005.0365 1060.5417 2004.7843 1060.5762 2004.3789 C 1060.8317 2000.9328 1061.1639 1998.3286 1061.5723 1996.5684 C 1061.8526 1995.2632 1065.4911 1993.9044 1072.4883 1992.4902 L 1063.6016 1987.9648 z M 1032.1719 1993.8496 C 1030.7154 1994.144 1028.5619 1994.6561 1025.709 1995.3887 C 1023.8611 1995.8644 1022.4147 1996.2135 1021.1523 1996.5039 L 1017.918 1994.8574 C 1014.8784 1995.4718 1011.9566 1995.8864 1009.1543 1996.1016 C 1009.2916 1996.3079 1010.6018 1998.2468 1013.084 2001.9199 C 1014.6642 2004.2927 1015.9542 2006.2567 1016.9531 2007.8105 C 1017.4284 2008.5613 1017.8397 2009.2487 1018.2617 2009.9453 L 1023.7891 2009.3711 C 1022.1773 2006.8987 1020.3409 2004.1185 1018.0625 2000.7383 C 1020.1669 2000.5289 1022.4355 2000.1978 1024.8555 1999.7539 L 1028.1777 2001.4453 C 1029.0327 2001.2726 1029.935 2001.0904 1030.8848 2000.8984 C 1032.4483 2003.0752 1034.2314 2005.486 1036.1797 2008.0742 L 1041.3086 2007.5137 C 1039.4 2004.9438 1037.5255 2002.3249 1035.7012 1999.6328 C 1037.7855 1999.0945 1039.5705 1998.6738 1041.0586 1998.373 L 1032.1719 1993.8496 z M 976.03711 2002.0137 C 975.31805 2002.0163 974.54206 2002.1016 973.71094 2002.2695 C 971.20966 2002.7751 968.66934 2003.8159 966.08984 2005.3906 L 974.89453 2009.873 C 976.56324 2008.8725 978.3587 2008.0598 980.2793 2007.4375 C 983.46537 2011.3585 986.87814 2016.0537 990.51953 2021.5215 C 991.75621 2023.3784 993.71749 2026.3762 996.40234 2030.5156 C 998.89524 2034.4208 1000.8668 2037.4368 1002.3184 2039.5625 C 1001.1294 2039.8808 998.57256 2040.437 994.64648 2041.2305 L 1003.5332 2045.7539 C 1004.0934 2045.6407 1004.036 2045.6449 1004.5371 2045.543 L 1003.041 2036.3945 L 1002.9785 2032.3262 L 986.64453 2008.2598 C 992.36497 2011.856 998.15345 2015.4179 1003.9746 2018.9648 L 1004.6895 2016.7402 C 995.74393 2011.505 987.23341 2006.8172 979.16406 2002.6895 C 978.27739 2002.2346 977.23555 2002.0093 976.03711 2002.0137 z "
-       id="path4359" />
-  </g>
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:67.07809448px;font-family:Fondamento;-inkscape-font-specification:Fondamento;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ba894f;fill-opacity:1;fill-rule:nonzero;stroke:#7b441d;stroke-width:5.05978775;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate">Grote Markt, Komona</flowPara></flowRoot>  </g>
 </svg>


### PR DESCRIPTION
The text on the pamphlet was not shown correctly, since the font was changed to another one since I translated this. This commit fixes that.

Furthermore, when I translated this, I interpreted 'Azarday, 3 Pinkmoon' as 'Azarday' being the weekday and '3 Pinkmoon' being the date (as in 'Tuesday, 3 January'). Now I read [here](https://github.com/Deevad/peppercarrot/wiki/Time-system) that Pinkmoon actually indicates time, so I changed the Dutch to reflect this.
